### PR TITLE
Make is broken on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 #CPPFLAGS= -Wc,-F/System/Library/PrivateFrameworks
 #LIBS= -Wl,-F/System/Library/PrivateFrameworks -framework Heimdal
 #KRB5=-DHAVE_KRB5 -DHEIMDAL_FRAMEWORK
@@ -9,8 +8,15 @@ KRB5=-DHAVE_KRB5
 
 ARCHS=i386 x86_64
 
-CFLAGS = -Wc,-g $(foreach arch,$(ARCHS),"-Wc,-arch $(arch)")
-LDFLAGS = -Wl,-g $(foreach arch,$(ARCHS),"-Wl,-arch $(arch)")
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+  CFLAGS = -Wc,-g $(foreach arch,$(ARCHS),"-Wc,-arch $(arch)")
+  LDFLAGS = -Wl,-g $(foreach arch,$(ARCHS),"-Wl,-arch $(arch)")
+else
+  CFLAGS = -Wc,-g
+  LDFLAGS = -Wl,-g
+endif
 
 APXS = apxs
 


### PR DESCRIPTION
When I run `make` on my Arch linux machine I get such error

Error 

```
$ LANG=en_EN make
apxs -o mod_spnego.la -c `krb5-config --cflags gssapi` -Wc,-g "-Wc,-arch i386" "-Wc,-arch x86_64" -Wl,-g "-Wl,-arch i386" "-Wl,-arch x86_64" -DHAVE_KRB5 mod_spnego.c `krb5-config --libs gssapi`
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_EN"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
/usr/share/apr-1/build/libtool --silent --mode=compile gcc -prefer-pic -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2  -DLINUX=2 -D_REENTRANT -D_GNU_SOURCE -pthread -I/usr/include/httpd  -I/usr/include/apr-1   -I/usr/include/apr-1 -I/usr/include -g -arch i386 -arch x86_64 -DHAVE_KRB5  -c -o mod_spnego.lo mod_spnego.c && touch mod_spnego.slo
gcc: error: i386: No such file or directory
gcc: error: x86_64: No such file or directory
gcc: error: unrecognized option '-arch'
gcc: error: unrecognized option '-arch'
apxs:Error: Command failed with rc=65536
.
make: *** [mod_spnego.la] Error 1
```

The reason is in fact that the `-arch` option is part of the Apple extensions to gcc. So I use `uname` to recognize what platform is used by user. May be GNU's automake/autoconf make it better, but `uname` is ok too.
