### PR TITLE
Enable NTLM only if code is compiled against Heimdal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #CPPFLAGS= -Wc,-F/System/Library/PrivateFrameworks
 #LIBS= -Wl,-F/System/Library/PrivateFrameworks -framework Heimdal
-#KRB5=-DHAVE_KRB5 -DHEIMDAL_FRAMEWORK
+#KRB5=-DHAVE_KRB5 -DHAVE_HEIMDAL
 
 CPPFLAGS= `krb5-config --cflags gssapi`
 LIBS= `krb5-config --libs gssapi`

--- a/mod_spnego.c
+++ b/mod_spnego.c
@@ -40,7 +40,7 @@
 #include <apr_strings.h>
 #include <apr_tables.h>
 
-#ifdef HEIMDAL_FRAMEWORK
+#ifdef HAVE_HEIMDAL
 #include <Heimdal/gssapi.h>
 #include <Heimdal/krb5.h>
 #else
@@ -51,7 +51,9 @@
 extern module AP_MODULE_DECLARE_DATA spnego_module;
 
 static const char *NEGOTIATE_NAME = "Negotiate";
+#ifdef HAVE_HEIMDAL
 static const char *NTLM_NAME = "NTLM";
+#endif
 static const char *WWW_AUTHENTICATE = "WWW-Authenticate";
 
 #define SPNEGO_DEBUG(c, r, ...)						\
@@ -246,7 +248,9 @@ check_user_id(request_rec *r)
     if (p == NULL) {
 	SPNEGO_DEBUG(c, r, "mod_spnego: no Authorization header");
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NEGOTIATE_NAME);
+#ifdef HAVE_HEIMDAL
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NTLM_NAME);
+#endif
 	return HTTP_UNAUTHORIZED;
     }
 
@@ -254,14 +258,22 @@ check_user_id(request_rec *r)
     if (mech == NULL) {
 	SPNEGO_DEBUG(c, r, "mod_spnego: Authorization header malformated");
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NEGOTIATE_NAME);
+#ifdef HAVE_HEIMDAL
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NTLM_NAME);
+#endif
 	return HTTP_UNAUTHORIZED;
     }
 
+#ifdef HAVE_HEIMDAL
     if (strcmp(mech, NEGOTIATE_NAME) != 0 && strcmp(mech, NTLM_NAME) != 0) {
+#else
+    if (strcmp(mech, NEGOTIATE_NAME)) {
+#endif
 	SPNEGO_DEBUG(c, r, "mod_spnego: auth not support: %s", mech);
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NEGOTIATE_NAME);
+#ifdef HAVE_HEIMDAL
 	apr_table_addn(r->err_headers_out, WWW_AUTHENTICATE, NTLM_NAME);
+#endif
 	return HTTP_UNAUTHORIZED;
     }
 


### PR DESCRIPTION
Make NTLM only work if we are on Heimdal GSS-API implementation which is most true for FreeBSD, etc. otherwise advertise SPNEGO only.
