### PR TITLE
Enable NTLM only if code is compiled against Heimdal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #CPPFLAGS= -Wc,-F/System/Library/PrivateFrameworks
 #LIBS= -Wl,-F/System/Library/PrivateFrameworks -framework Heimdal
-#KRB5=-DHAVE_KRB5 -DHEIMDAL_FRAMEWORK
+#KRB5=-DHAVE_KRB5 -DHAVE_HEIMDAL
 
 CPPFLAGS= `krb5-config --cflags gssapi`
 LIBS= `krb5-config --libs gssapi`


### PR DESCRIPTION
Make NTLM only work if we are on Heimdal GSS-API implementation which is most true for FreeBSD, etc. otherwise advertise SPNEGO only.
